### PR TITLE
Added NETINTERFACE variable for support of non-eth0 interface

### DIFF
--- a/pentest.sh
+++ b/pentest.sh
@@ -406,16 +406,19 @@ f_nmapscans(){ #nmap scans of targets
 	do
 		f_progressquick "NMAP Progress"
 		TARGET=${i}
+		echo "Target: " ${TARGET}
 		LOC=${OUTPUTDIR}/${TARGET}
+		echo "here we go"
 		if [ -d ${LOC} ] ; then sleep 0 ; else mkdir -p ${LOC} ; fi
 		if [ ${NMAPTCPDEFAULT} = "1" ] ; then ((COUNT++)); sleep ${SLEEPTIME}; xterm ${XTERMVALS} -title "${TARGET} NMAP small TCP" -e "${NMAPTCP} ${LOC}/small.tcp ${TARGET}" & fi
 		if [ ${NMAPTCPALL} = "1" ] ; then ((COUNT++)); sleep ${SLEEPTIME}; xterm ${XTERMVALS} -title "${TARGET} NMAP big TCP" -e "${NMAPTCP} ${LOC}/big.tcp -p- ${TARGET}" & fi
-		if [ ${NMAPTCPCUSTOM} = "1" ] ; then ((COUNT++)); sleep ${SLEEPTIME}; xterm ${XTERMVALS} -title "${TARGET} NMAP custom TCP" -e "${NMAPTCP} ${LOC}/custom.tcp -p${NMAPTCPCUSTOMPORTS} ${TARGET}" & fi
+		if [ ${NMAPTCPCUSTOM} = "1" ] ; then ((COUNT++)); sleep ${SLEEPTIME} && echo "bloop"; xterm ${XTERMVALS} -title "${TARGET} NMAP custom TCP" -e "${NMAPTCP} ${LOC}/custom.tcp -p${NMAPTCPCUSTOMPORTS} ${TARGET}" & fi
 		if [ ${NMAPUDPDEFAULT} = "1" ] ; then ((COUNT++)); sleep ${SLEEPTIME}; xterm ${XTERMVALS} -title "${TARGET} NMAP small UDP" -e "${NMAPUDP} ${LOC}/small.udp ${TARGET}" & fi
 		if [ ${NMAPUDPALL} = "1" ] ; then ((COUNT++)); sleep ${SLEEPTIME}; xterm ${XTERMVALS} -title "${TARGET} NMAP big UDP" -e "${NMAPUDP} ${LOC}/big.udp -p- ${TARGET}" & fi
-		if [ ${NMAPUDPCUSTOM} = "1" ] ; then ((COUNT++)); sleep ${SLEEPTIME}; xterm ${XTERMVALS} -title "${TARGET} NMAP custom UDP" -e "${NMAPUDP} ${LOC}/custom.udp -p${NMAPUDPCUSTOMPORTS} ${TARGET}" & fi
+		if [ ${NMAPUDPCUSTOM} = "1" ] ; then ((COUNT++)); sleep ${SLEEPTIME} ; xterm ${XTERMVALS} -title "${TARGET} NMAP custom UDP" -e "${NMAPUDP} ${LOC}/custom.udp -p${NMAPUDPCUSTOMPORTS} ${TARGET}" & fi
 		while [ `ps -Aef --cols 400 | grep NMAP | grep xterm | wc -l` -ge ${THREADS} ]
 		do
+			echo "in loop"
 			f_progress "NMAP Progress"
 		done
 		sleep 5

--- a/pentest.sh
+++ b/pentest.sh
@@ -129,6 +129,7 @@
 
 # Program
 f_setdefaults(){ #defaults for running the script
+	NETINTERFACE="eth0"
 	NMAPTCP="nmap -sS -vv -A -Pn -n -r -oA" # this needs to finish with -oA and cannot include -p
 	NMAPUDP="nmap -sU -vv -A -Pn -n -r -oA" # this needs to finish with -oA and cannot include -p
 	NMAPQUICKPORTS="7,13,17,19,21,22,23,25,50,53,69,80,111,123,135,137,139,161,199,443,445,500,1434,1556,2049,2301,2381,3181,3389,5353,8080,8081,8161,47001"
@@ -274,17 +275,17 @@ f_directorycheck(){ #creates dir if it's not present
 f_scansource(){ #creates scansource.txt containing network info
 	echo -e "\e[00;32m[SCANSOURCE]\e[00m"
 	echo  "[+] Now creating scansource.txt `echotime`"
-	ipaddr=`ifconfig eth0 | grep "inet addr" | cut -d":" -f2 | cut -d" " -f1`
-	netmask=`ifconfig eth0 | grep "Mask" | cut -d":" -f4`
+	ipaddr=`ifconfig ${NETINTERFACE} | grep "inet addr" | cut -d":" -f2 | cut -d" " -f1`
+	netmask=`ifconfig ${NETINTERFACE} | grep "Mask" | cut -d":" -f4`
 	f_mask2cidr ${netmask} #cidr is now /24 /25 /23 and so on
 	echo "[+] Interface Details----------------" > ${OUTPUTDIR}/scansource.txt
-	ifconfig eth0 | sed '/^$/d' >> ${OUTPUTDIR}/scansource.txt
+	ifconfig ${NETINTERFACE} | sed '/^$/d' >> ${OUTPUTDIR}/scansource.txt
 	echo -e "\n[+] Route Details--------------------" >> ${OUTPUTDIR}/scansource.txt
 	route -n >> ${OUTPUTDIR}/scansource.txt
 	echo -e "\n[+] IPCalc Details-------------------" >> ${OUTPUTDIR}/scansource.txt
 	ipcalc -n -b "${ipaddr}" "${netmask}" >> ${OUTPUTDIR}/scansource.txt
 	echo -e "\n[+] Arp-Scan Details-----------------" >> ${OUTPUTDIR}/scansource.txt
-	arp-scan -l | grep -v packets | grep -v Ending | grep -v Starting | grep -v Interface | sed '/^$/d' >> ${OUTPUTDIR}/scansource.txt
+	arp-scan -I ${NETINTERFACE} -l | grep -v packets | grep -v Ending | grep -v Starting | grep -v Interface | sed '/^$/d' >> ${OUTPUTDIR}/scansource.txt
 	echo -e "\n[+] NMAP Ping Sweep Details-----------------" >> ${OUTPUTDIR}/scansource.txt
 	nmap -sP "${ipaddr}/${cidr}" | grep -v "Host is up" | sed -e 's/Nmap scan report for //' | grep -v Nmap | grep -v "${ipaddr}" | sed ':a;N;$!ba;s/\nMAC Address: / /g' | sed '/^$/d' >> ${OUTPUTDIR}/scansource.txt
 	echo -e "\n[+] nbtscan -----------------" >> ${OUTPUTDIR}/scansource.txt
@@ -340,7 +341,7 @@ f_arpscan(){ #creates targets.txt and then allows editing
 		fi
 	fi
 	echo  "[+] We are now scanning the local subnet for devices using arp-scan `echotime`"
-	arp-scan -l -g | grep . | grep -v ${MACIGNORE} | cut -f1 | grep -v packets |grep -v Interface | grep -v Ending | grep -v Starting | sort -bt . -k 1,1n -k 2,2n -k 3,3n -k 4,4n | uniq > `pwd`/targets.txt
+	arp-scan -I ${NETINTERFACE} -l -g | grep . | grep -v ${MACIGNORE} | cut -f1 | grep -v packets |grep -v Interface | grep -v Ending | grep -v Starting | sort -bt . -k 1,1n -k 2,2n -k 3,3n -k 4,4n | uniq > `pwd`/targets.txt
 	echo "[+] Arp-Scan complete. Please remove IPs you dont wish to scan `echotime`" ; sleep 3
 	nano `pwd`/targets.txt
 	cp `pwd`/targets.txt ${OUTPUTDIR}/targets.txt


### PR DESCRIPTION
Was looking at a few things discovered that the interface is hardcoded to eth0. Added a simple variable to cater for wireless/eth1/etc...

Now by default it's eth0 but it can be customised using the custom-config.conf file to be whatever you wish. Appears to work here at least but you may want to test it on your end.
